### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   publish:
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/titoinemb/ChatyKick/security/code-scanning/1](https://github.com/titoinemb/ChatyKick/security/code-scanning/1)

In general, the fix is to explicitly declare the GitHub Actions token permissions using a `permissions:` block, instead of relying on repository defaults. This block can be added either at the workflow root (applies to all jobs) or within the specific job. Since we only see a single job and CodeQL’s highlight is near the job definition, the best non‑disruptive change is to add `permissions:` under the `publish` job. We should grant only what’s needed: read access to repository contents, and write access for releases. `tauri-apps/tauri-action` uses the token to create or update releases and upload assets, which maps to the `contents: write` scope (and/or `id-token`/`attestations` in more advanced setups, but not needed here). To stay minimal but functional, we can set `contents: write` and leave other scopes at their default `none`.

Concretely, in `.github/workflows/tauri-release.yml`, under `jobs: publish:`, insert a `permissions:` block before the `strategy:` key. This will ensure that the `GITHUB_TOKEN` used by all steps in that job has exactly the specified permissions. No additional imports or external dependencies are needed; this is purely a YAML configuration change to the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
